### PR TITLE
Paste! button tweak

### DIFF
--- a/pinnwand/static/pinnwand.css
+++ b/pinnwand/static/pinnwand.css
@@ -111,8 +111,15 @@ section.paste-submit {
 }
 
 section.paste-submit button {
-    font-size: 1rem;
+    border: none;
+    border-radius: 0.2em;
+    padding: 0.4rem 1.4rem;
+    margin: 0 0.2rem;
+    background: var(--color3);
+    color: var(--color1);
     cursor: pointer;
+    font-size: 1.1rem;
+    text-align: center;
 }
 
 


### PR DESCRIPTION
Fixes #38 

<img width="440" alt="bpaste-tweaked-button" src="https://user-images.githubusercontent.com/882547/74091960-2d271880-4abe-11ea-8d95-c3463314b9f3.png">

I'm not entirely happy with the color, but this was the easiest.