### PR TITLE
Add toml to main package dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -431,7 +431,7 @@ postgresql_psycopg2cffi = ["psycopg2cffi"]
 pymysql = ["pymysql"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python Library for Tom's Obvious, Minimal Language"
 name = "toml"
 optional = false
@@ -518,7 +518,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "80dee8afccc679e423770cb637e5735883567de1661dff845e4a8fec1fac9e3e"
+content-hash = "b94e11e86a86b3310c05d2a36f27f4b44fc89f4eb14f24ba826a7eea7d36fd46"
 python-versions = ">=3.6,<4"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ pygments = "^2.4"
 sqlalchemy = "^1.3"
 click = "^7.0"
 docutils = "^0.16"
+toml = "^0.10.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Looks like `toml` wasn't included as a dependency in the current release. After `pip` installing in a fresh virtualenv:
```
$ pinnwand --configuration-path test.toml http
Traceback (most recent call last):
  File "/Users/jesse/.pyenv/versions/pinnwand/bin/pinnwand", line 5, in <module>
    from pinnwand.__main__ import main
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/pinnwand/__main__.py", line 3, in <module>
    main()
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/click/core.py", line 1134, in invoke
    Command.invoke(self, ctx)
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/jesse/.pyenv/versions/3.6.0/envs/pinnwand/lib/python3.6/site-packages/pinnwand/command.py", line 28, in main
    import toml
ModuleNotFoundError: No module named 'toml'
```

I'm not too experienced with `poetry`, but I basically just ran `poetry add toml` and this diff was the result. I tested building and installing this version and it seems to work.