### PR TITLE
Add a button to toggle word wrap, closes #51.

### DIFF
--- a/pinnwand/static/pinnwand.css
+++ b/pinnwand/static/pinnwand.css
@@ -53,6 +53,23 @@ a:hover {
     color: var(--color1);
 }
 
+button.btn-link {
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--color3);
+    font-family: sans-serif;
+    font-size: 13px;
+    text-decoration: underline;
+    cursor: pointer;
+    display: inline;
+}
+
+button.btn-link:hover {
+    background-color: var(--color3);
+    color: var(--color1);
+}
+
 span.gh {
     color: var(--color-pygments-gh);
 }

--- a/pinnwand/static/pinnwand.js
+++ b/pinnwand/static/pinnwand.js
@@ -2,6 +2,17 @@ window.addEventListener("load", function(event) {
     var bar = document.querySelector("section.paste-submit");
 
     if(!bar) {
+        // Not the new paste page.
+        var wordWrapButton = document.getElementById("toggle-word-wrap");
+        if(wordWrapButton != null) {
+            wordWrapButton.addEventListener("click", function(event) {
+                var codeBlocks = document.querySelectorAll("div.code");
+                for(var i = 0; i < codeBlocks.length; i++) {
+                    codeBlocks[i].classList.toggle("no-word-wrap");
+                }
+            });
+        }
+
         return false;
     }
 

--- a/pinnwand/static/pygments.css
+++ b/pinnwand/static/pygments.css
@@ -11,6 +11,11 @@
     line-height: normal;
 }
 
+div.code.no-word-wrap .source pre,
+div.code.no-word-wrap .sourcetable td.code code {
+    white-space: pre;
+}
+
 .sourcetable td.linenos {
     vertical-align: top;
     padding-left: 5px;

--- a/pinnwand/template/show.html
+++ b/pinnwand/template/show.html
@@ -14,6 +14,8 @@
 
         <a href="/repaste/{{ paste.slug }}">Repaste</a> this paste.
 
+        <button class="btn-link" id="toggle-word-wrap">Toggle word wrap</button>.
+
         Pasted through <em>{{ paste.src }}</em>.
         </p>
     </div>


### PR DESCRIPTION
This is a quick little PR for #51. The button is non-intrusive and looks like a link. I made word-wrap the default behavior, but it would be trivial to change it around. The change is applied to all files on the page, but it’s not persisted anywhere.