### PR TITLE
Add lexer autodetection

### DIFF
--- a/pinnwand/database.py
+++ b/pinnwand/database.py
@@ -135,6 +135,10 @@ class File(Base):  # type: ignore
 
         self.lexer = lexer
 
+        if lexer == 'autodetect':
+            lexer = utility.guess_language(raw, filename)
+            log.debug(f"Language guessed as {lexer}")
+
         lexer = pygments.lexers.get_lexer_by_name(lexer)
         formatter = BetterHtmlFormatter(  # pylint: disable=no-member
             linenos="table", cssclass="source"

--- a/test/test_utility.py
+++ b/test/test_utility.py
@@ -3,3 +3,55 @@ from pinnwand import utility
 
 def test_expiries() -> None:
     assert len(utility.expiries) == 2
+
+
+def test_guess_language() -> None:
+    # python
+    assert utility.guess_language("""
+      import math
+      math.ceil(0.5)
+    """) == "python"
+    assert utility.guess_language("""
+      # this is a comment
+    """, "__init__.py") == "python"
+
+    # bash
+    assert utility.guess_language("""
+      #!/usr/bin/bash
+      set -euxo pipefail
+    """, "script.sh") == "bash"
+
+    # php
+    assert utility.guess_language("""
+      <?php
+      $var = 0.5;
+      abs($var);
+    """).endswith("php")  # for some reason this is guessed as js+php
+
+    # yaml
+    assert utility.guess_language("""
+      ---
+      one:
+        two: 3
+        four: five
+    """, "some.yml") == "yaml"
+
+    # rst
+    assert utility.guess_language("""
+      Title
+      =====
+
+      Subtitle
+      --------
+      - One
+      - Two
+    """, "doc.rst") == "rst"
+
+    # markdown
+    assert utility.guess_language("""
+      # Title
+      ## Subtitle
+      [Link](http://www.example.com)
+      ~~Strikethrough~~
+    """, "doc.md") == "md"
+


### PR DESCRIPTION
This is a first look into autodetection of the appropriate lexer, which we discussed in #83. I don't believe that it's finished yet, as it gets some crucial languages wrong.

Current testset:
- https://gist.github.com/mweinelt/28979f8a857153a6bedbedd79f42630a#file-text-md 
- https://gist.github.com/mweinelt/28979f8a857153a6bedbedd79f42630a#file-text_filename-md

The accuracy is spot on with proper filenames, less so when we rely on text only. But that is to be expected.

I'm especially concerned with `rst` files being detected and then reverting back to something odd like `mysql`.or `ssp`