### PR TITLE
Add a report link for problematic cases

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ New features all around.
 * Sum up filesizes and check against paste size. This change now makes the
   paste size limit the total size, not a per-file limit! Adjust your
   configuration accordingly. (#89)
+* Add a report link for files that may be problematic, this link will be
+  added only if the ``report_email`` field is set to anything than None in the
+  configuration file. (#2)
 
 v1.1.3 (20200620)
 *****************

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -59,6 +59,9 @@ with. Here's an example file::
   # empty no help text will be shown.
   paste_help = "<p>Welcome to pinnwand, this site is a pastebin. It allows you to share code with others. If you write code in the text area below and press the paste button you will be given a link you can share with others so they can view your code as well.</p><p>People with the link can view your pasted code, only you can remove your paste and it expires automatically. Note that anyone could guess the URI to your paste so don't rely on it being private.</p>"
 
+  # Email used for file reporting. If the value is not None then a href with a mailto link will be added to every paste page thus allowing the users to report pastes that may need removal.
+  report_email = "maintainer@example.com"
+
 Options
 *******
 
@@ -119,3 +122,11 @@ HTML to render above the new paste page to help users on how to use your
 instance.
 
 Default: ``bunch of html``
+
+report_email
+============
+
+An email address that allows users to report a paste that may need removal or
+edition.
+
+Default: ``None``

--- a/pinnwand/configuration.py
+++ b/pinnwand/configuration.py
@@ -6,3 +6,4 @@ page_path = None
 page_list = ["about", "removal", "expiry"]
 preferred_lexers = []  # type: ignore
 logo_path = None
+report_email = None

--- a/pinnwand/template/show.html
+++ b/pinnwand/template/show.html
@@ -31,6 +31,9 @@
                     Filename: {{ file.filename }}.
                     Size: {{ file.pretty_size }}.
                     View <a href="/raw/{{ file.slug }}">raw</a>, <button class="btn-link copy-button">copy</button>, <a href="/hex/{{ file.slug }}">hex</a>, or <a href="/download/{{ file.slug }}">download</a> this file.
+                    {% if handler.application.configuration.report_email %}
+                    <a href="mailto:{{ handler.application.configuration.report_email }}?subject=Pinnwand report (File ID: {{ file.slug }})">Report</a> this file.
+                    {% end %}
                 </div>
             </div>
             {% end %}


### PR DESCRIPTION
This PR solves #2 by adding a link at the end of a paste to make the users able to report problematic pastes.

This href will be displayed only if `report_email` is configured to something else than `None`