### PR TITLE
Add line highlighting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ More quality of life and code quality changes.
 * Add a ``resyntax`` command to rerun lexer over all pastes (#70)
 * Paste expiry options now come from the configuration file (#53)
 * Convert tabs/enters to indentation, contributed by millefalcon_ (#90)
+* Add line highlighting (#39)
 
 v1.2.2 (20200829)
 *****************

--- a/pinnwand/static/line-highlighter.js
+++ b/pinnwand/static/line-highlighter.js
@@ -1,0 +1,81 @@
+(() => {
+
+let fileTableBodies;
+let hashChangedByClick = false;
+
+window.addEventListener("DOMContentLoaded", () => {
+    fileTableBodies = document.querySelectorAll("table.sourcetable tbody");
+    if (fileTableBodies.length === 0) {
+        return;
+    }
+
+    window.addEventListener("hashchange", onHashChange);
+    addEventListenerToFileTableBodies();
+
+    if (window.location.hash !== "") {
+        highlightLine({ hash: window.location.hash, scrollIntoView: true });
+    }
+});
+
+function onHashChange(event) {
+    let oldUrl = new URL(event.oldURL);
+    let newUrl = new URL(event.newURL);
+    highlightLine({ hash: oldUrl.hash, scrollIntoView: false });
+    highlightLine({ hash: newUrl.hash, scrollIntoView: !hashChangedByClick });
+    hashChangedByClick = false;
+}
+
+function addEventListenerToFileTableBodies() {
+    for (let fileIndex = 0; fileIndex < fileTableBodies.length; fileIndex++) {
+        let fileTableBody = fileTableBodies[fileIndex];
+        fileTableBody.addEventListener("click", (event) => {
+            let lineNumber;
+            let t = event.target;
+            if (t.classList.contains("linenos")) {
+                lineNumber = t.firstElementChild.dataset.lineNumber;
+            } else if (t.dataset.hasOwnProperty("lineNumber")) {
+                lineNumber = t.dataset.lineNumber;
+            }
+            if (lineNumber) {
+                setFileLineHash(fileIndex + 1, parseInt(lineNumber, 10));
+                hashChangedByClick = true;
+            }
+        });
+    }
+}
+
+function highlightLine({ hash, scrollIntoView }) {
+    let { fileIndex, lineIndex } = getFileLineIndexFromHash(hash);
+    if (fileIndex === null || fileIndex >= fileTableBodies.length) {
+        return;
+    }
+    let tableRows = fileTableBodies[fileIndex].children;
+    if (lineIndex >= tableRows.length) {
+        return;
+    }
+    let tableRow = tableRows[lineIndex];
+    let code = tableRow.querySelector("td.code");
+    code.classList.toggle("highlighted");
+    if (scrollIntoView) {
+        code.scrollIntoView();
+    }
+}
+
+function getFileLineIndexFromHash(hash) {
+    let splitHash = hash.substring(1).split("L");
+    let [ fileIndex, lineIndex ] = splitHash.map((x) => {
+        return parseInt(x, 10) - 1;
+    });
+    if (isNaN(fileIndex) || isNaN(lineIndex)
+            || fileIndex < 0 || lineIndex < 0) {
+        return { fileIndex: null, lineIndex: null };
+    } else {
+        return { fileIndex, lineIndex };
+    }
+}
+
+function setFileLineHash(fileNumber, lineNumber) {
+    window.location.hash = `${fileNumber}L${lineNumber}`;
+}
+
+})();

--- a/pinnwand/static/pinnwand.css
+++ b/pinnwand/static/pinnwand.css
@@ -243,6 +243,7 @@ td.linenos {
     background: var(--color0);
     padding: 0 .25rem;
     opacity: .5;
+    cursor: pointer;
 }
 
 div.code {
@@ -256,6 +257,7 @@ div.code:hover td.linenos {
 
 td.code {
     padding-left: .5rem;
+    width: 100%;
 }
 
 pre {
@@ -365,6 +367,10 @@ div.code.no-word-wrap .sourcetable td.code code {
 
 textarea.copy-area {
     display: none;
+}
+
+.highlighted {
+    background-color: rgba(255,223,93,0.2);
 }
 
 .hll { background-color: #ffffcc }

--- a/pinnwand/template/layout.html
+++ b/pinnwand/template/layout.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="{{ static_url('pinnwand.css') }}" type="text/css">
     <link rel="shortcut icon" href="/static/favicon.png">
     <script type="text/javascript" src="{{ static_url('pinnwand.js') }}"></script>
+    <script type="text/javascript" src="{{ static_url('line-highlighter.js') }}"></script>
   </head>
   <body>
     <header>


### PR DESCRIPTION
Users can now click on the line numbers to highlight a line. They can share the link of the page and visitors will be scrolled to the line. The way this works is by storing the file number and line number in the hash of the URL.

Hash: #1L6
Will highlight the first file's 6th line.

https://user-images.githubusercontent.com/32761424/103143947-96237900-46ee-11eb-939c-39adeba24b87.mp4

Resolves #39