### PR TITLE
contrib: import hardened systemd units

### DIFF
--- a/contrib/pinnwand-reaper.service
+++ b/contrib/pinnwand-reaper.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Pinnwand Reaper
+Documentation=https://pinnwand.readthedocs.io/en/latest/
+
+[Service]
+CapabilityBoundingSet=
+DevicePolicy=closed
+DynamicUser=true
+ExecStart=/usr/local/bin/pinnwand --configuration-path /etc/pinnwand.toml -vvvv reap
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+RestrictAddressFamilies=AF_UNIX
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+StateDirectory=pinnwand
+StateDirectoryMode=0700
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+UMask=0077
+User=pinnwand
+

--- a/contrib/pinnwand-reaper.timer
+++ b/contrib/pinnwand-reaper.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Clear expired pastes regularly
+
+[Timer]
+AccuracySec=43200s
+FixedRandomDelay=true
+OnCalendar=daily
+Persistent=yes
+RandomizedDelaySec=24h
+Unit=pinnwand-reaper.service
+
+[Install]
+WantedBy=timers.target

--- a/contrib/pinnwand.service
+++ b/contrib/pinnwand.service
@@ -1,0 +1,38 @@
+[Unit]
+After=network.target
+Description=Pinnwannd HTTP Server
+Documentation=https://pinnwand.readthedocs.io/en/latest/
+
+[Service]
+CapabilityBoundingSet=
+DevicePolicy=closed
+DynamicUser=true
+ExecStart=/usr/local/bin/pinnwand --configuration-path /etc/pinnwand.toml http --port 4100
+LockPersonality=true
+MemoryDenyWriteExecute=true
+PrivateDevices=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectClock=true
+ProtectControlGroups=true
+ProtectHome=true
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+RestrictAddressFamilies=AF_UNIX
+RestrictAddressFamilies=AF_INET
+RestrictAddressFamilies=AF_INET6
+RestrictNamespaces=true
+RestrictRealtime=true
+StateDirectory=pinnwand
+StateDirectoryMode=0700
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~@privileged @resources
+UMask=0077
+User=pinnwand
+
+[Install]
+WantedBy=multi-user.target

--- a/pinnwand.service-example
+++ b/pinnwand.service-example
@@ -1,9 +1,0 @@
-[Unit]
-Description=pinnwand pastebin
-
-[Service]
-ExecStart=/home/youruser/virtual-environment/bin/pinnwand --configuration-path /home/youruser/pinnwand.toml http
-Restart=always
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
I developed these for the NixOS module and have been using them with
SQLite for quite some time.

And as promised, here they are. Cleaned up from all the NixOS-specific mess. I took the liberty to create the contrib directory as not to mess up the root any further.

If required I can also group these settings and add some comments here and there.

These options were tested against sytemd v246 and v247.

```
[root@juno:~]# systemd-analyze security pinnwand.service | grep -v "✓"
  NAME                                                        DESCRIPTION                                                                    EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                            0.5
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                               0.3
✗ DeviceAllow=                                                Service has a device ACL with some special devices                                  0.1
✗ IPAddressDeny=                                              Service does not define an IP address allow list                                    0.2
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                       0.1
✗ RestrictAddressFamilies=~AF_UNIX                            Service may allocate local sockets                                                  0.1

→ Overall exposure level for pinnwand.service: 1.1 OK 🙂
````

