### PR TITLE
Added fix for mypy complaining about already defined name

### DIFF
--- a/pinnwand/command.py
+++ b/pinnwand/command.py
@@ -35,7 +35,7 @@ def main(verbose: int, configuration_path: Optional[str]) -> None:
         try:
             import tomllib as toml
         except ImportError:
-            import tomli as toml # type: ignore # see https://github.com/python/mypy/issues/1153
+            import tomli as toml  # type: ignore # see https://github.com/python/mypy/issues/1153
 
         with open(configuration_path, "rb") as file:
             configuration_file = toml.load(file)

--- a/pinnwand/command.py
+++ b/pinnwand/command.py
@@ -35,7 +35,7 @@ def main(verbose: int, configuration_path: Optional[str]) -> None:
         try:
             import tomllib as toml
         except ImportError:
-            import tomli as toml
+            import tomli as toml # type: ignore # see https://github.com/python/mypy/issues/1153
 
         with open(configuration_path, "rb") as file:
             configuration_file = toml.load(file)


### PR DESCRIPTION
@supakeen  Added a quick  [fix](https://github.com/python/mypy/issues/1153#issuecomment-253842414) for `mypy` complaining about already defined name

```bash
$ mypy pinnwand
pinnwand/command.py:38:13: error: Name "toml" already defined (possibly by an import)
Found 1 error in 1 file (checked 15 source files)
```

Please see the mypy issue [1152](https://github.com/python/mypy/issues/1153#issuecomment-253842414)