### PR TITLE
Add ctrl+s shortcut to save a paste

### DIFF
--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -3,6 +3,18 @@ let indents = {
     "python2": " ".repeat(4),
 };
 
+document.addEventListener('keydown', e => {
+    if ((e.ctrlKey && !e.altKey) && e.key === 's') {
+        let submitButton = document.querySelector("button#pasteSubmit");
+        // Only trigger on pages that have a submit button
+        if (submitButton) {
+            // Prevent the Save dialog from opening
+            e.preventDefault();
+            submitButton.click();
+        }
+    }
+});
+
 window.addEventListener("load", (event) => {
     setupColorScheme();
 


### PR DESCRIPTION
This only eats the ctrl+s input if the paste submit button is present in the DOM.

We also ensure that we are not capturing ctrl+alt+s inputs to avoid catching the Polish S. See https://medium.engineering/the-curious-case-of-disappearing-polish-s-fa398313d4df

Closes #148