### PR TITLE
Point users to an exhaustive list of supported lexers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -39,6 +39,7 @@ with. Here's an example file::
   # Preferred lexers. This list of lexers will appear on top of the dropdown
   # on the website allowing you to preselect commonly used lexers. Note that the
   # names here have to be the identifiers used by pygments, not the human names.
+  # The keys returned by /api/v1/lexer are an exhaustive list of supported lexers.
   # If empty no preferred lexers are shown.
   preferred_lexers = []
   


### PR DESCRIPTION
When configuring this list myself it took me a while to figure out what keys are actually supported in this config list. Mostly due to [pygments docs](https://pygments.org/languages/) listing a few short names for each language, however only 1 of each would actually work in this config list.