### PR TITLE
Except SyntaxError when parsing env var using literal_eval

### DIFF
--- a/src/pinnwand/command.py
+++ b/src/pinnwand/command.py
@@ -57,7 +57,7 @@ def main(verbose: int, configuration_path: Optional[str]) -> None:
 
             try:
                 value = ast.literal_eval(value)
-            except ValueError:
+            except (ValueError, SyntaxError):
                 # When `ast.literal_eval` can't parse the value into another
                 # type we take it at string value
                 pass


### PR DESCRIPTION
For example, database_uri will contain a ':', which will raise a SynxtaxError in literal_eval, causing the script to exit