### PR TITLE
Limit height not width for logos to allow for banner-style logos

### DIFF
--- a/src/asset/pinnwand.scss
+++ b/src/asset/pinnwand.scss
@@ -214,7 +214,7 @@ header nav ul {
         vertical-align: middle;
 
         img.logo {
-            width: 3rem;
+            height: 5rem;
         }
     }
 }

--- a/src/pinnwand/static/pinnwand.css
+++ b/src/pinnwand/static/pinnwand.css
@@ -171,7 +171,7 @@ header nav ul {
     display: inline-block;
     vertical-align: middle; }
     header nav ul li img.logo {
-      width: 3rem; }
+      height: 5rem; }
 
 div.file-show {
   margin-top: .5rem; }


### PR DESCRIPTION
As this logo is at the top of the page, width either side being white space, this is a prime spot for using a banner-style logo. By limiting the image height, rather than width, this allows the logo to take up as much horizontal space as it likes.

## Default logo
Before
![image](https://github.com/supakeen/pinnwand/assets/9753350/c815b3c4-adc3-4a4d-9527-45f01cc22320)
After
![image](https://github.com/supakeen/pinnwand/assets/9753350/7c89ecf8-d298-4a59-8319-56a07ae36ac5)

## Banner-style logo
Before
![image](https://github.com/supakeen/pinnwand/assets/9753350/bbb91c89-1ee2-4960-b739-ff23a501ce44)

After
![image](https://github.com/supakeen/pinnwand/assets/9753350/2c2d6a6b-85ff-42be-8e3e-a30803a69084)
