### PR TITLE
Use correct query when selecting the submit button

### DIFF
--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -5,7 +5,7 @@ let indents = {
 
 document.addEventListener('keydown', e => {
     if ((e.ctrlKey && !e.altKey) && e.key === 's') {
-        let submitButton = document.querySelector("button#pasteSubmit");
+        let submitButton = document.querySelector("button");
         // Only trigger on pages that have a submit button
         if (submitButton) {
             // Prevent the Save dialog from opening


### PR DESCRIPTION
This was previously incorrect due to a dirty work tree on my part, where I had added the pasteSubmit id to the paste button. Now that this is not present, button#pasteSubmit is not a valid element