### PR TITLE
Update ci

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,83 @@
+name: Build & Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  build-base:
+    name: Build & push base image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker image metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+            images: ghcr.io/supakeen/pinnwand
+            tags: |
+                type=ref,event=tag,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+                type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Containerfile
+          target: base
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=registry,ref=ghcr.io/supakeen/pinnwand:latest
+          cache-to: type=inline
+          tags: ${{ steps.meta.outputs.tags }}
+
+  build-additional-images:
+    name: Build & push additional images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        container-stage: ["psql","mysql"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate docker image metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/supakeen/pinnwand
+          tags: |
+              type=ref,event=tag,suffix=-${{ matrix.container-stage }},enable=${{ startsWith(github.ref, 'refs/tags/') }}
+              type=raw,value=latest-${{ matrix.container-stage }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Containerfile
+          target: ${{ matrix.container-stage }}
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+          cache-from: type=registry,ref=ghcr.io/supakeen/pinnwand:latest-${{ matrix.container-stage }}
+          cache-to: type=inline
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,32 +1,25 @@
 name: Linters
 
 on:
-  push:
-  pull_request:
+  workflow_call:
 
 jobs:
-  black:
+  lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install black codespell
+        pip install -r requirements.txt
+        pip install black codespell types-docutils mypy
+
     - name: Check with black
       run: black --check src/pinnwand
-#  mypy:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - uses: actions/checkout@v2
-#    - name: Set up Python
-#      uses: actions/setup-python@v2
-#    - name: Install dependencies
-#      run: |
-#        python -m pip install --upgrade pip
-#        pip install -r requirements.txt
-#        pip install types-docutils mypy
-#    - name: Check with mypy
-#      run: mypy src/pinnwand
+
+    # - name: Check with mypy
+    #   run: mypy src/pinnwand

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,3 +16,5 @@ jobs:
     uses: ./.github/workflows/test.yaml
   vuln:
     uses: ./.github/workflows/vuln.yaml
+  build-push:
+    uses: ./.github/workflows/build.yaml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  release:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    uses: ./.github/workflows/lint.yaml
+  test:
+    uses: ./.github/workflows/test.yaml
+  vuln:
+    uses: ./.github/workflows/vuln.yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,33 +1,34 @@
-name: CI
+name: Test
 
 on:
-  push:
-  pull_request:
+  workflow_call:
   schedule:
   # run at 7:00 on the first of every month
   - cron: '0 7 1 * *'
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.python-version == 'pypy-3.7' }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install pytest pytest-cov
+
     - name: Test with pytest
       run: |
         pytest --cov=pinnwand

--- a/.github/workflows/vuln.yaml
+++ b/.github/workflows/vuln.yaml
@@ -1,31 +1,24 @@
 name: Vulnerability Scanners
 
 on:
-  push:
-  pull_request:
+  workflow_call:
 
 jobs:
   bandit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install bandit
+        pip install bandit pip-audit
+
     - name: Check with bandit
       run: bandit -r src/pinnwand
-  pip-audit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pip-audit
+
     - name: Check with pip-audit
       run: pip-audit --requirement requirements.txt


### PR DESCRIPTION
Closes #152 

This PR comes with a few changes.

I have merged the jobs in the linting workflow, as well as merged the jobs in the test workflow. This means the working environment only needs to be setup once for each job, rather than duplicating.

I have moved CI to a reusable workflow style, this makes it easier to track what is going on, as it all appears on 1 page. See [this page](https://github.com/python-discord/pinnwand/actions/runs/5165700569/jobs/9305379886) for the CI passing in test on my fork.

I have added a new build workflow. This runs on every push & pull request.
Thanks to the line `push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}` the container is only pushed to GHCR if running on master, or from a tag.
Images being pushed are always tagged with `latest`, `latst-psql` and `latest-mysql`.
If building from a tag, `<tagname>`, `<tagname>-psql` and `<tagname>-mysql` are also pushed.

I have also updates all CI steps to their latest versions.

I renamed the previous "Build" workflow to "Test" so that I could use "Build" namespace for the container building workflow.