### PR TITLE
Add copy URL button to view paste page

### DIFF
--- a/src/asset/pinnwand.scss
+++ b/src/asset/pinnwand.scss
@@ -151,7 +151,8 @@ section.paste-submit {
 }
 
 div.file-meta button,
-section.paste-submit button {
+section.paste-submit button,
+.copyurl {
     box-sizing: border-box;
     border: .0625rem solid var(--color3);
     padding: .4rem 1.4rem;
@@ -164,7 +165,8 @@ section.paste-submit button {
 }
 
 div.file-meta button:hover,
-section.paste-submit button:hover {
+section.paste-submit button:hover,
+.copyurl:hover {
     color: var(--color3);
     background: var(--color1);
     border: .0625rem solid var(--color3);

--- a/src/pinnwand/static/pinnwand.css
+++ b/src/pinnwand/static/pinnwand.css
@@ -121,7 +121,8 @@ section.paste-submit {
   padding: .5rem; }
 
 div.file-meta button,
-section.paste-submit button {
+section.paste-submit button,
+.copyurl {
   box-sizing: border-box;
   border: 0.0625rem solid var(--color3);
   padding: .4rem 1.4rem;
@@ -133,7 +134,8 @@ section.paste-submit button {
   text-align: center; }
 
 div.file-meta button:hover,
-section.paste-submit button:hover {
+section.paste-submit button:hover,
+.copyurl:hover {
   color: var(--color3);
   background: var(--color1);
   border: 0.0625rem solid var(--color3); }

--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -167,6 +167,12 @@ function setupShowPage() {
         });
     };
 
+    let shareButton = document.getElementById("copyurl-btn");
+
+    shareButton.addEventListener("click", function(event) {
+        navigator.clipboard.writeText(window.location.href);
+    });
+
     return false;
 }
 

--- a/src/pinnwand/template/show.html
+++ b/src/pinnwand/template/show.html
@@ -36,6 +36,7 @@
                     <a href="mailto:{{ handler.application.configuration.report_email }}?subject=Pinnwand report (File ID: {{ file.slug }})">Report</a> this file.
                     {% end %}
                 </div>
+                <button class="copyurl" id="copyurl-btn">Copy URL</button>
             </div>
             {% end %}
         </div>


### PR DESCRIPTION
Closes #164 

Add a "Copy URL" button to the view paste page that allows users to quickly copy the paste URL into their clipboard for sharing. The site now looks like the below image:
![image](https://github.com/supakeen/pinnwand/assets/74519799/391aaf4a-d119-4776-a549-19b47f363162)
