### PR TITLE
Fix incorrect documentation of `ratelimit.read.refill` default

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -216,7 +216,7 @@ Default: `1`
 
 ratelimit.read.refill
 ^^^^^^^^^^^^^^^^^^^^^
-Default: `1`
+Default: `2`
 
 ratelimit.create.capacity
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The actual default config:
https://github.com/supakeen/pinnwand/blob/240f29d81b8d3752611d67ab59e9fef82e526e94/src/pinnwand/configuration.py#L12-L28

The correct value is what's described above ("So the read bucket below allows a burst of a 100 reads then another 2 per second.") and used earlier in the file.