### PR TITLE
Add line range(s) highlight support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ v1.5.0 (unreleased)
 * Ctrl+S now submits pastes by ChrisLovering_.
 * `pdm` is now used as the build backend and package solution.
 * Containers are now published by CI to GHCR_ by ChrisLovering_.
+* Add line range(s) highlight support.
 
 v1.4.0 (20221127)
 *****************


### PR DESCRIPTION
Sometimes user wants to highlight a range instead of just one line, this PR adds support for doing that.

This PR also adds support for highlighting ranges for many files at once.

GitHub itself also only support highlighting one range per file, so we won't bother implementing many ranges per file just yet unless there is a demand for it. (Also our line range extension algo is slightly different to that in GitHub, oh wells.)

The states required for this functionality demands more complexity as such we have added more internal states for tracking it, and actively sync it with the ground truth (the newest window location hash) when it changes.