### PR TITLE
use `project.scripts` instead of `tool.poetry.scripts` for entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ dev = [
 requires = ["pdm-pep517>=1.0"]
 build-backend = "pdm.pep517.api"
 
+[project.scripts]
+pinnwand = 'pinnwand.__main__:main'
+
 [tool.black]
 line-length = 80
 target_version = ["py36"]
@@ -63,8 +66,6 @@ exclude = '''
   | dist
 )/
 '''
-[tool.poetry.scripts]
-pinnwand = 'pinnwand.__main__:main'
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]


### PR DESCRIPTION
After the change from poetry to pdm in #121, it appears that some build systems have trouble groking what scripts to install due to the use of the poetry-specific entrypoint configuration in pyproject.toml.

This change updates the pyproject.toml to use the
[PEP-621](https://www.python.org/dev/peps/pep-0621) specification for identifying console_scripts/entrypoints, and resolves the build issue on Fedora. From my testing, there is no impact for installations via e.g. `pip`, as these tools will understand PEP-621 entrypoint specifications.