### PR TITLE
Bootstrap logging

### DIFF
--- a/src/pinnwand/command.py
+++ b/src/pinnwand/command.py
@@ -9,10 +9,12 @@ import sys
 from datetime import timedelta
 from typing import TYPE_CHECKING, Optional
 
+from pinnwand import logger
+
 import click
 import tornado.ioloop
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 @click.group()

--- a/src/pinnwand/database.py
+++ b/src/pinnwand/database.py
@@ -1,6 +1,5 @@
 import contextlib
 import datetime
-import logging
 from datetime import timedelta
 from typing import Optional
 
@@ -23,9 +22,9 @@ from sqlalchemy.orm import (
 )
 from sqlalchemy.orm.session import Session
 
-from pinnwand import configuration, defensive, error, utility
+from pinnwand import configuration, defensive, error, logger, utility
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 _engine = create_engine(configuration.database_uri)
 _session = sessionmaker(bind=_engine)

--- a/src/pinnwand/defensive.py
+++ b/src/pinnwand/defensive.py
@@ -1,14 +1,13 @@
 import ipaddress
-import logging
 import re
 from typing import Dict, Union
 
 import token_bucket
 from tornado.httputil import HTTPServerRequest
 
-from pinnwand import configuration
+from pinnwand import configuration, logger
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 ratelimit_area: Dict[

--- a/src/pinnwand/handler/api_curl.py
+++ b/src/pinnwand/handler/api_curl.py
@@ -1,11 +1,10 @@
-import logging
 from urllib.parse import urljoin
 
 import tornado.web
 
-from pinnwand import configuration, database, defensive, utility
+from pinnwand import configuration, database, defensive, logger, utility
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 class Create(tornado.web.RequestHandler):

--- a/src/pinnwand/handler/api_deprecated.py
+++ b/src/pinnwand/handler/api_deprecated.py
@@ -1,5 +1,4 @@
 import json
-import logging
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urljoin
@@ -8,9 +7,9 @@ import tornado.escape
 import tornado.web
 from tornado.escape import url_escape
 
-from pinnwand import configuration, database, defensive, error, utility
+from pinnwand import configuration, database, defensive, error, logger, utility
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 class Base(tornado.web.RequestHandler):

--- a/src/pinnwand/handler/api_v1.py
+++ b/src/pinnwand/handler/api_v1.py
@@ -1,14 +1,13 @@
 import json
-import logging
 from datetime import datetime, timedelta
 from typing import Any
 from urllib.parse import urljoin
 
 import tornado.web
 
-from pinnwand import configuration, database, defensive, error, utility
+from pinnwand import configuration, database, defensive, error, logger, utility
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 class Base(tornado.web.RequestHandler):

--- a/src/pinnwand/handler/website.py
+++ b/src/pinnwand/handler/website.py
@@ -7,7 +7,15 @@ from typing import Any
 import docutils.core
 import tornado.web
 
-from pinnwand import configuration, database, defensive, error, logger, path, utility
+from pinnwand import (
+    configuration,
+    database,
+    defensive,
+    error,
+    logger,
+    path,
+    utility,
+)
 
 log = logger.get_logger(__name__)
 

--- a/src/pinnwand/handler/website.py
+++ b/src/pinnwand/handler/website.py
@@ -1,6 +1,5 @@
 import binascii
 import io
-import logging
 import zipfile
 from datetime import datetime
 from typing import Any
@@ -8,9 +7,9 @@ from typing import Any
 import docutils.core
 import tornado.web
 
-from pinnwand import configuration, database, defensive, error, path, utility
+from pinnwand import configuration, database, defensive, error, logger, path, utility
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 class Base(tornado.web.RequestHandler):

--- a/src/pinnwand/http.py
+++ b/src/pinnwand/http.py
@@ -1,12 +1,11 @@
-import logging
 import secrets
 from typing import Any, List
 
 import tornado.web
 
-from pinnwand import configuration, handler, path
+from pinnwand import configuration, handler, logger, path
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 def make_application(debug: bool = False) -> tornado.web.Application:

--- a/src/pinnwand/logger.py
+++ b/src/pinnwand/logger.py
@@ -7,7 +7,9 @@ def get_logger(name: str) -> LoggerClass:
     logger = logging.getLogger(name)
 
     for handler in logger.handlers:
-        formatter = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+        formatter = logging.Formatter(
+            "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+        )
         handler.setFormatter(formatter)
 
     return logger

--- a/src/pinnwand/logger.py
+++ b/src/pinnwand/logger.py
@@ -1,0 +1,13 @@
+import logging
+
+LoggerClass = logging.getLoggerClass()
+
+
+def get_logger(name: str) -> LoggerClass:
+    logger = logging.getLogger(name)
+
+    for handler in logger.handlers:
+        formatter = logging.Formatter("%(asctime)s | %(name)s | %(levelname)s | %(message)s")
+        handler.setFormatter(formatter)
+
+    return logger

--- a/src/pinnwand/utility.py
+++ b/src/pinnwand/utility.py
@@ -1,4 +1,3 @@
-import logging
 import math
 import re
 from base64 import b32encode
@@ -12,9 +11,9 @@ from pygments.lexers import (
     guess_lexer_for_filename,
 )
 
-from pinnwand import database
+from pinnwand import database, logger
 
-log = logging.getLogger(__name__)
+log = logger.get_logger(__name__)
 
 
 def list_languages() -> Dict[str, str]:


### PR DESCRIPTION
Closes #213 

This PR introduces a new `logger` module that would bootsrapp the instantiation of loggers + enforce the same formattings all over the app.


@supakeen Regarding the configuration, what exactly do you want to configure?
Like I mentioned in the issue, you'd generally want to configure the `log level`, but you could also configure the handlers.
For the handlers, we can have a list of tuples in the config file, where the tuple would include the `FQDN` of a handler class, which will allow us to dynamically import it.

The problem with this though is the casting string types to different classes (That are not always native python types), that each handler might need.

