### PR TITLE
Document api v1 paste show endpoint

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -66,7 +66,7 @@ sufficient.
 
 
 /api/v1/paste/([A-Z2-7]+)(?:#.+)?
---------------------------------
+---------------------------------
 Used to retrieve the paste with the given ID.
 
   >>> requests.get("http://localhost:8000/api/v1/paste/74").json()

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -65,6 +65,14 @@ To remove a paste a ``GET`` request to the ``removal`` URL returned is
 sufficient.
 
 
+/api/v1/paste/([A-Z2-7]+)(?:#.+)?
+--------------------------------
+Used to retrieve the paste with the given ID.
+
+  >>> requests.get("http://localhost:8000/api/v1/paste/74").json()
+  {"files": [{"name": "spam", "lexer": "python", "content": "eggs"}]}
+
+
 /api/v1/lexer
 -------------
 An endpoint to list all lexers available in the ``pinnwand`` instance whose


### PR DESCRIPTION
This was added in https://github.com/supakeen/pinnwand/pull/194 but with the note that docs are still needed.