### PR TITLE
Fix warnings when building docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -135,7 +135,7 @@ lower priority.
 v1.1.1 (20200602)
 *****************
 *The traditional bugfix release for the previous release. No real bugs here
-but something to prevent CSS changes from not being loaded.
+but something to prevent CSS changes from not being loaded.*
 
 * Prevent browsers from aggressively caching (#74)
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Previously got these warnings from a fresh docs build
```python
(venv) PS D:\pinnwand\doc> sphinx-build . _build -E
Running Sphinx v7.2.6
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).   
making output directory... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 7 source files that are out of date
updating environment: [new config] 7 added, 0 changed, 0 removed
reading sources... [100%] usage
../CHANGELOG.rst:137: WARNING: Inline emphasis start-string without end-string.
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... copying static files... done
copying extra files... done
done
writing output... [100%] usage
generating indices... genindex py-modindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 2 warnings.
```