### PR TITLE
Fix: New log formats not being displayed

### DIFF
--- a/src/pinnwand/__init__.py
+++ b/src/pinnwand/__init__.py
@@ -1,0 +1,3 @@
+from .logger import setup_logging
+
+setup_logging()

--- a/src/pinnwand/logger.py
+++ b/src/pinnwand/logger.py
@@ -3,13 +3,13 @@ import logging
 LoggerClass = logging.getLoggerClass()
 
 
+def setup_logging():
+    """Sets up basic log levels & formats."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(name)s | %(levelname)s | %(message)s",
+    )
+
+
 def get_logger(name: str) -> LoggerClass:
-    logger = logging.getLogger(name)
-
-    for handler in logger.handlers:
-        formatter = logging.Formatter(
-            "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
-        )
-        handler.setFormatter(formatter)
-
-    return logger
+    return logging.getLogger(name)


### PR DESCRIPTION
As I was testing the image on my local cluster, i noticed that the formatting I've setup in my previous PR hasn't taken effect.

This is because when we ask for a new logger, it doesn't come with any handlers.

The solution to this is to use `logging.basicConfig` upon package instantiation.

I know that we previously discussed this, but I said it was a problem if we put it in `__main__.py` as it'll only be available when the server is launched, and not if it's used as a package. And I don't know why I didn't think about putting it in the package's `__init__.py` .

@supakeen I know i've kep the `get_logger` method even though it does practically nothing.
I just wanted to reduce the changes and also let room for extra setup if we're ever going to do that.
Also, what do you think about making the log level configurable ?

![image](https://github.com/supakeen/pinnwand/assets/48383734/037f75f5-b2a0-49dd-8a68-feb416c0cdd8)


