### PR TITLE
Add crud utilities

### DIFF
--- a/src/pinnwand/crud.py
+++ b/src/pinnwand/crud.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+import logging
+from typing import NamedTuple
+
+import tornado
+from sqlalchemy.orm.session import Session
+
+from pinnwand import configuration, database, utility
+from pinnwand.error import ValidationError
+
+class PastedFile(NamedTuple):
+    lexer: str
+    content: str
+    filename: str | None
+
+class PasteResult(NamedTuple):
+    paste_slug: str
+    removal_slug: str
+
+log = logging.getLogger(__name__)
+
+def create_paste(session, files: list[PastedFile], expiry: str | int, auto_scale: bool, source: str) -> PasteResult:
+    if len(files) == 0:
+        raise ValidationError("No files provided")
+    
+    if isinstance(expiry, str):
+        try:
+            expiry_seconds = configuration.expiries[expiry]
+        except KeyError:
+            log.info("Paste.post: a paste was submitted with an invalid expiry")
+            raise ValidationError(f"Invalid expiry {expiry!r}. Allowed values are {tuple(configuration.expiries.keys())!r}.")
+    else:
+        expiry_seconds = expiry
+    
+    with utility.SlugContext(auto_scale) as slug_context:
+        paste = database.Paste(
+            next(slug_context),
+            expiry_seconds,
+            source,
+        )
+
+        # TODO: add test for total_size check
+        total_size = 0
+        for file in files:        
+            db_file = database.File(
+                next(slug_context),
+                file.content,
+                file.lexer,
+                file.filename,
+            )
+
+            total_size += len(db_file.fmt)
+            if total_size > configuration.paste_size:
+                raise ValidationError(
+                    "Sum of file sizes exceeds size limit when syntax highlighting applied "
+                    f"({total_size//1024}kB > {configuration.paste_size//1024}kB)"
+                )
+
+            paste.files.append(db_file)
+
+    # For the first file we will always use the same slug as the paste,
+    # since slugs are generated to be unique over both pastes and files
+    # this can be done safely.
+    paste.files[0].slug = paste.slug
+
+    session.add(paste)
+    session.commit()
+
+    return PasteResult(paste.slug, paste.removal)
+
+def error_if_expired_or_none(session, paste_or_file: database.Paste | database.File | None) -> None:
+    if paste_or_file is None:
+        raise tornado.web.HTTPError(404, "Paste not found")
+    
+    if isinstance(paste_or_file, database.File):
+        paste = paste_or_file.paste
+    else:
+        paste = paste_or_file
+
+    if paste.exp_date < datetime.utcnow():
+        session.delete(paste)
+        session.commit()
+
+        # TODO: consider removing this warning or making it an 
+        # error that takes the reap interval into account.
+        log.warning(
+            "Paste was expired but still existed in the database."
+        )
+        raise tornado.web.HTTPError(404, "Paste not found")
+
+
+def get_file(session: Session, slug: str) -> database.Paste:
+    file = session.query(database.File).filter(database.File.slug == slug).one_or_none()
+    error_if_expired_or_none(session, file)
+    
+    return file
+
+def get_paste(session: Session, slug: str) -> database.Paste:
+    paste = session.query(database.Paste).filter(database.Paste.slug == slug).one_or_none()
+    error_if_expired_or_none(session, paste)
+    
+    return paste
+
+def get_paste_by_removal(session: Session, slug: str) -> database.Paste:
+    paste = session.query(database.Paste).filter(database.Paste.removal == slug).one_or_none()
+    error_if_expired_or_none(session, paste)
+
+    return paste

--- a/src/pinnwand/handler/api_curl.py
+++ b/src/pinnwand/handler/api_curl.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 import tornado.web
 
-from pinnwand import configuration, database, defensive, logger, utility
+from pinnwand import crud, database, defensive, logger, error
 
 log = logger.get_logger(__name__)
 
@@ -13,6 +13,14 @@ class Create(tornado.web.RequestHandler):
 
     def get(self) -> None:
         raise tornado.web.HTTPError(400)
+    
+    def write_error(self, status_code: int, **kwargs) -> None:
+        type_, exc, _ = kwargs["exc_info"]
+        if type_ is error.ValidationError:
+            self.set_status(400)
+            self.write({"state": "error", "code": status_code, "message": str(exc)})
+        
+        super().write_error(status_code, **kwargs)
 
     def post(self) -> None:
         if defensive.ratelimit(self.request, area="create"):
@@ -25,49 +33,22 @@ class Create(tornado.web.RequestHandler):
         expiry = self.get_body_argument("expiry", "1day")
 
         self.set_header("Content-Type", "text/plain")
-
-        if lexer not in utility.list_languages():
-            log.info(
-                "CurlCreate.post: a paste was submitted with an invalid lexer"
-            )
-            self.set_status(400)
-            self.write("Invalid `lexer` supplied.\n")
-            return
-
-        # Guard against empty strings
-        if not raw or not raw.strip():
-            log.info("CurlCreate.post: a paste was submitted without raw")
-            self.set_status(400)
-            self.write("Invalid `raw` supplied.\n")
-            return
-
-        if expiry not in configuration.expiries:
-            log.info("CurlCreate.post: a paste was submitted without raw")
-            self.set_status(400)
-            self.write("Invalid `expiry` supplied.\n")
-            return
-
-        paste = database.Paste(
-            utility.slug_create(), configuration.expiries[expiry], "curl"
-        )
-        file = database.File(paste.slug, raw, lexer)
-        paste.files.append(file)
-
+        
+        files = [crud.PastedFile(lexer, raw, "curl")]
         with database.session() as session:
-            session.add(paste)
-            session.commit()
+            paste = crud.create_paste(session, files, expiry, auto_scale=True, source="curl")
 
-            # The removal cookie is set for the specific path of the paste it is
-            # related to
-            self.set_cookie(
-                "removal", str(paste.removal), path=f"/{paste.slug}"
-            )
+        # The removal cookie is set for the specific path of the paste it is
+        # related to
+        self.set_cookie(
+            "removal", paste.removal_slug, path=f"/{paste.paste_slug}"
+        )
 
-            url_request = self.request.full_url()
-            url_paste = urljoin(url_request, f"/{paste.slug}")
-            url_removal = urljoin(url_request, f"/remove/{paste.removal}")
-            url_raw = urljoin(url_request, f"/raw/{file.slug}")
+        url_request = self.request.full_url()
+        url_paste = urljoin(url_request, f"/{paste.paste_slug}")
+        url_removal = urljoin(url_request, f"/remove/{paste.removal_slug}")
+        url_raw = urljoin(url_request, f"/raw/{paste.paste_slug}")
 
-            self.write(
-                f"Paste URL:   {url_paste}\nRaw URL:     {url_raw}\nRemoval URL: {url_removal}\n"
-            )
+        self.write(
+            f"Paste URL:   {url_paste}\nRaw URL:     {url_raw}\nRemoval URL: {url_removal}\n"
+        )


### PR DESCRIPTION
Not ready yet, just opening as a draft. Sorry for the large PR, I think it's worth it though.

This makes a lot of logic shared to reduce the amount of code there is and fix and help prevent some issues:
- https://github.com/supakeen/pinnwand/issues/182: RE "Are pastes being reaped on all show pages?", the repaste endpoint doesn't currently, but this fixes that and ensures it can't be forgotten in the future
- The previous logic for checking if a paste with multiple files went over the file size when the files were combined only checked the total size once all the files were processed. This meant you could have e.g. 100 files just under the size limit individually and DoS the server because it has to process them all with pygments. Now an error is raised as soon as the combined size goes above the max allowed.
- Some validation logic was inconsistent across different endpoints (most endpoints consider whitespace an empty paste which isn't allowed, but `api_v1` didn't). Centralising the logic ensures all endpoints are consistent when they should be.

To Do:
- Add tests
- Add docstrings
- Tidy up code
- Make sure error responses are in the correct format for each endpoint respectively.