### PR TITLE
fix logo lookup

### DIFF
--- a/src/pinnwand/app.py
+++ b/src/pinnwand/app.py
@@ -62,14 +62,27 @@ def make_application(debug: bool = False) -> tornado.web.Application:
     if configuration.logo_path:
         pages += [
             (
-                r"/static/logo.png",
+                r"/logo.png",
                 handler.website.Logo,
                 {"path": configuration.logo_path},
             ),
             (
-                r"/static/favicon.png",
+                r"/favicon.png",
                 handler.website.Logo,
                 {"path": configuration.logo_path},
+            ),
+        ]
+    else:
+        pages += [
+            (
+                r"/logo.png",
+                handler.website.Logo,
+                {"path": path.static / "logo.png"},
+            ),
+            (
+                r"/favicon.png",
+                handler.website.Logo,
+                {"path": path.static / "logo.png"},
             ),
         ]
 

--- a/src/pinnwand/handler/website.py
+++ b/src/pinnwand/handler/website.py
@@ -595,7 +595,10 @@ class Logo(Base):
         self.path = path
 
     async def get(self) -> None:
-        self.set_header("Content-Type", "image/png")
 
-        with open(self.path, "rb") as f:
-            self.write(f.read())
+        try:
+            with open(self.path, "rb") as f:
+                self.write(f.read())
+                self.set_header("Content-Type", "image/png")
+        except FileNotFoundError:
+            raise tornado.web.HTTPError(404)

--- a/src/pinnwand/template/layout.html
+++ b/src/pinnwand/template/layout.html
@@ -3,7 +3,7 @@
   <head>
     <title>{{ pagetitle }}</title>
     <link rel="stylesheet" href="{{ static_url('pinnwand.css') }}" type="text/css">
-    <link rel="shortcut icon" href="/static/favicon.png">
+    <link rel="shortcut icon" href="/favicon.png">
     <script type="text/javascript" src="{{ static_url('pinnwand.js') }}"></script>
   </head>
   <body>
@@ -11,7 +11,7 @@
       <nav>
         <ul>
           <li>
-            <a href="/"><img class="logo" src="/static/logo.png"></a>
+            <a href="/"><img class="logo" src="/logo.png"></a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
Closes #108.

Should still work for those instances that directly overwrite the static file in the static directory but now also work for instances that use `logo_path`.

Seems to be some finicky stuff with the Tornado static handler and route specificity?