### PR TITLE
fix: faded the View Paste page buttons

### DIFF
--- a/src/pinnwand/template/show.html
+++ b/src/pinnwand/template/show.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <main class="paste-show{% if len(paste.files) > 1 %} multiple{% end %}">
-    <div class="paste-actions">
+    <div class="paste-actions paste-meta">
         <a class="new-paste" href="/">New paste</a>
 
         <a class="handle-paste" href="/repaste/{{ paste.slug }}">Repaste</a>


### PR DESCRIPTION
Faded the View Paste page buttons to make them less bright (distracting)
![2024-03-10_21h52_47](https://github.com/supakeen/pinnwand/assets/49349130/6c6f1197-34b3-4cbf-9063-bd372b441325)
![2024-03-10_21h52_53](https://github.com/supakeen/pinnwand/assets/49349130/fda0163d-f06b-45cb-bb98-bb39b94a8193)
