### PR TITLE
fix AttributeError thrown by str.removeprefix when python < 3.9

### DIFF
--- a/src/pinnwand/configuration.py
+++ b/src/pinnwand/configuration.py
@@ -114,13 +114,13 @@ class Configuration:
 
     def load_environment(self):
         """Load configuration from the environment, if any."""
+        prefix = "PINNWAND_"
         for key, value in os.environ.items():
-            if not key.startswith("PINNWAND_"):
+            if not key.startswith(prefix):
                 continue
 
-            key = key.removeprefix("PINNWAND_")
+            key = key[len(prefix) :]
             key = key.lower()
-
             try:
                 value = ast.literal_eval(value)
                 setattr(self, f"_{key}", value)

--- a/src/pinnwand/handler/website.py
+++ b/src/pinnwand/handler/website.py
@@ -595,7 +595,6 @@ class Logo(Base):
         self.path = path
 
     async def get(self) -> None:
-
         try:
             with open(self.path, "rb") as f:
                 self.write(f.read())

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -1,0 +1,26 @@
+from pinnwand.configuration import Configuration
+import tempfile
+import toml
+
+
+def test_load_environment_config(monkeypatch):
+    monkeypatch.setenv("PINNWAND_SPAMSCORE", "29")
+    config = Configuration()
+    config.load_environment()
+    assert config.spamscore == 29
+
+
+def test_load_file_config():
+    with tempfile.NamedTemporaryFile(suffix="", delete=False) as temp:
+
+        props = toml.load(temp.name)
+        url = "sqlite:///database.db"
+        props["database_uri"] = url
+
+        with open(temp.name, "w") as config_file:
+            toml.dump(props, config_file)
+            config: Configuration = Configuration()
+
+        config.load_config_file(temp.name)
+        assert config.database_uri == url
+


### PR DESCRIPTION
Closes #252

Sorry for that, I forgot about the python 3.8 support.