### PR TITLE
Allow loading configuration from .env files. #229

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -15,8 +15,16 @@ Here is a quick example::
 The ``http`` subcommand takes a separate argument ``--port`` to override
 the default listening port (8000).
 
-Any value in this file can be overridden by passing `PINNWAND_DATABASE_URI` in
-the environment (for example).
+Any value in this file can be overriden by setting its equivalent in the environment or in a `.env` file.
+
+To do that, all environment variables need to be in the form of `PINNWAND_{{option}}`.
+For example, if we wanted to override the `database_uri` option, we will define our value like the following::
+
+   PINNWAND_DATABASE_URI="hello"
+
+.. note::
+    * Any variable in the actual environment will take precedence over its equivalent in the `.env` file.
+    * It's best to place the `.env` at the root directory of the project, to avoid including it into VCS.
 
 File
 ****

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:3ae067e0dd4513cb2f15e4e1c7bcf0617d16594481578c55da9e91b9372e577d"
+content_hash = "sha256:a1d2e245c8350af379963adad03a3a7d34992b3baf4f5302faf3588b6dc977fc"
 
 [[package]]
 name = "bandit"
@@ -1111,6 +1111,16 @@ dependencies = [
 files = [
     {file = "pytest-playwright-0.4.4.tar.gz", hash = "sha256:5488db4cc49028491c5130af0a2bb6b1d0b222a202217f6d14491d4c9aa67ff9"},
     {file = "pytest_playwright-0.4.4-py3-none-any.whl", hash = "sha256:df306f3a60a8631a3cfde1b95a2ed5a89203a3408dfa1154de049ca7de87c90b"},
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.0.1"
+requires_python = ">=3.8"
+summary = "Read key-value pairs from a .env file and set them as environment variables"
+files = [
+    {file = "python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca"},
+    {file = "python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pygments-better-html>=0.1.4",
     "token-bucket>=0.3.0",
     "tomli>=2.0.1",
+    "python-dotenv>=1.0.1",
 ]
 requires-python = ">=3.8"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -498,6 +498,9 @@ pytest-metadata==3.0.0 \
 pytest-playwright==0.4.4 \
     --hash=sha256:5488db4cc49028491c5130af0a2bb6b1d0b222a202217f6d14491d4c9aa67ff9 \
     --hash=sha256:df306f3a60a8631a3cfde1b95a2ed5a89203a3408dfa1154de049ca7de87c90b
+python-dotenv==1.0.1 \
+    --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
+    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
 python-slugify==8.0.1 \
     --hash=sha256:70ca6ea68fe63ecc8fa4fcf00ae651fc8a5d02d93dcd12ae6d4fc7ca46c4d395 \
     --hash=sha256:ce0d46ddb668b3be82f4ed5e503dbc33dd815d83e2eb6824211310d3fb172a27
@@ -643,4 +646,3 @@ virtualenv==20.24.7 \
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
-

--- a/src/pinnwand/configuration.py
+++ b/src/pinnwand/configuration.py
@@ -1,6 +1,7 @@
 import ast
 import os
 from typing import Optional, TYPE_CHECKING
+from dotenv import load_dotenv
 
 if TYPE_CHECKING:  # lie to mypy, see https://github.com/python/mypy/issues/1153
     import tomllib as toml
@@ -112,9 +113,11 @@ class Configuration:
             for key, value in loaded_configuration.items():
                 setattr(self, f"_{key}", value)
 
-    def load_environment(self):
+    def load_environment(self, dotenv_file_path: Optional[str] = None):
         """Load configuration from the environment, if any."""
         prefix = "PINNWAND_"
+        load_dotenv(dotenv_path=dotenv_file_path, override=False)
+
         for key, value in os.environ.items():
             if not key.startswith(prefix):
                 continue

--- a/test/integration/test_config.py
+++ b/test/integration/test_config.py
@@ -1,12 +1,38 @@
+import os
+
 from pinnwand.configuration import Configuration
 import tempfile
 import toml
+import pytest
 
 
-def test_load_environment_config(monkeypatch):
+@pytest.fixture(scope="function")
+def temp_dotenv_file():
+
+    with tempfile.NamedTemporaryFile(mode="w+", delete=False) as file:
+        path = file.name
+
+    yield path
+    os.remove(path)
+
+
+def test_load_environment_config(temp_dotenv_file, monkeypatch):
     monkeypatch.setenv("PINNWAND_SPAMSCORE", "29")
+    with open(temp_dotenv_file, "w+") as file:
+        file.write("PINNWAND_PASTE_SIZE=524288")
     config = Configuration()
-    config.load_environment()
+    config.load_environment(dotenv_file_path=temp_dotenv_file)
+    assert config.spamscore == 29
+    assert config.paste_size == 524288
+
+
+def test_env_variables_precedence(monkeypatch, temp_dotenv_file):
+    monkeypatch.setenv("PINNWAND_SPAMSCORE", "29")
+    with open(temp_dotenv_file, "w+") as file:
+        file.write("PINNWAND_SPAMSCORE=31")
+
+    config = Configuration()
+    config.load_environment(dotenv_file_path=temp_dotenv_file)
     assert config.spamscore == 29
 
 


### PR DESCRIPTION
Closes #227, Closes #158

The changes in this PR will now allow configuring pinnwand through a `.env` file.

The configuration in the `.env` file **will not** take precedence over its equivalent in the system's environment.