### PR TITLE
Consume the right amount of tokens from the ratelimit bucket

### DIFF
--- a/src/pinnwand/handler/api_curl.py
+++ b/src/pinnwand/handler/api_curl.py
@@ -31,7 +31,6 @@ class Create(tornado.web.RequestHandler):
 
     @defensive.ratelimit(area="create")
     def post(self) -> None:
-
         configuration: Configuration = ConfigurationProvider.get_config()
         lexer = self.get_body_argument("lexer", "text")
         raw = self.get_body_argument("raw", "", strip=False)

--- a/test/integration/test_http_api.py
+++ b/test/integration/test_http_api.py
@@ -1,20 +1,23 @@
 import json
+import copy
 import urllib.parse
-
+import unittest.mock
 import tornado.testing
 import tornado.web
 
 from pinnwand.configuration import Configuration, ConfigurationProvider
-configuration: Configuration = ConfigurationProvider.get_config()
-
-configuration._ratelimit["read"]["capacity"] = 2**64 - 1
-configuration._ratelimit["create"]["capacity"] = 2**64 - 1
-configuration._ratelimit["delete"]["capacity"] = 2**64 - 1
-
 from pinnwand import app, utility
 from pinnwand.database import manager, utils as database_utils
 
+configuration: Configuration = ConfigurationProvider.get_config()
 
+
+ratelimit_copy = copy.deepcopy(configuration._ratelimit)
+for area in ("read", "create", "delete"):
+    ratelimit_copy[area]["capacity"] = 2**64 - 1
+
+
+@unittest.mock.patch.dict(configuration._ratelimit, ratelimit_copy)
 class DeprecatedAPITestCase(tornado.testing.AsyncHTTPTestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -117,7 +120,6 @@ class DeprecatedAPITestCase(tornado.testing.AsyncHTTPTestCase):
             ),
         )
 
-        print(response.body)
         assert response.code == 200
 
     def test_api_new_large_file(self) -> None:

--- a/test/integration/test_http_ratelimit.py
+++ b/test/integration/test_http_ratelimit.py
@@ -1,0 +1,90 @@
+import copy
+import time
+import unittest.mock
+
+import tornado.testing
+import tornado.web
+
+from pinnwand import app, configuration, defensive
+
+
+class RateLimitTestCase(tornado.testing.AsyncHTTPTestCase):
+
+    def get_app(self) -> tornado.web.Application:
+        return app.make_application()
+
+    def test_ratelimit_verification_on_endpoints(self):
+        with unittest.mock.patch("pinnwand.defensive.should_be_ratelimited") as patch:
+            patch.return_value = False
+
+            self.fetch(
+                "/",
+                method="GET",
+            )
+
+            patch.assert_called()
+            patch.reset_mock()
+
+    def test_ratelimit_application_on_one_client(self):
+        config = configuration.ConfigurationProvider.get_config()
+        ratelimlit_copy = copy.deepcopy(config._ratelimit)
+        ratelimlit_copy["read"]["capacity"] = 2
+        ratelimlit_copy["read"]["consume"] = 2
+        ratelimlit_copy["read"]["refill"] = 1
+
+        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
+            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+                response = self.fetch(
+                    "/",
+                    method="GET",
+                )
+
+                assert response.code == 200
+
+                response = self.fetch(
+                    "/",
+                    method="GET",
+                )
+
+                assert response.code == 429
+
+    def test_ratelimit_application_on_multiple_clients(self):
+        config = configuration.ConfigurationProvider.get_config()
+        ratelimlit_copy = copy.deepcopy(config._ratelimit)
+        area = "read"
+        ratelimlit_copy[area]["capacity"] = 10
+        ratelimlit_copy[area]["consume"] = 7
+        ratelimlit_copy[area]["refill"] = 1
+
+        ip1 = "192.168.15.32"
+        ip2 = "10.45.134.23"
+
+        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
+            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+                assert defensive.should_be_ratelimited(ip1, area) is False
+                assert defensive.should_be_ratelimited(ip1, area) is True
+                assert defensive.should_be_ratelimited(ip2, area) is False
+                assert defensive.should_be_ratelimited(ip2, area) is True
+                assert defensive.should_be_ratelimited(ip2, area) is True
+                time.sleep(10)  # Give it enough time to replenish
+                assert defensive.should_be_ratelimited(ip1, area) is False
+                assert defensive.should_be_ratelimited(ip2, area) is False
+
+    def test_bucket_tokens_consumption(self):
+        config = configuration.ConfigurationProvider.get_config()
+        ratelimlit_copy = copy.deepcopy(config._ratelimit)
+        area = "read"
+        consumption = 7
+        capacity = 10
+        ratelimlit_copy[area]["capacity"] = capacity
+        ratelimlit_copy[area]["consume"] = consumption
+        ratelimlit_copy[area]["refill"] = 1
+
+        ip = "192.168.15.32"
+        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
+            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+                defensive.should_be_ratelimited(ip, area)
+                limiter = defensive.ratelimit_area[area]
+                tokens_remaining = limiter._storage.get_token_count(ip.encode("utf-8"))
+                assert tokens_remaining == capacity - consumption
+

--- a/test/integration/test_http_website.py
+++ b/test/integration/test_http_website.py
@@ -1,20 +1,22 @@
 import urllib.parse
-
+import unittest.mock
 import tornado.testing
 import tornado.web
-
+import copy
 
 from pinnwand.configuration import Configuration, ConfigurationProvider
-configuration: Configuration = ConfigurationProvider.get_config()
-
-configuration._ratelimit["read"]["capacity"] = 2**64 - 1
-configuration._ratelimit["create"]["capacity"] = 2**64 - 1
-configuration._ratelimit["delete"]["capacity"] = 2**64 - 1
-
 from pinnwand import app
 from pinnwand.database import manager, utils as database_utils
 
+configuration: Configuration = ConfigurationProvider.get_config()
 
+
+ratelimit_copy = copy.deepcopy(configuration._ratelimit)
+for area in ("read", "create", "delete"):
+    ratelimit_copy[area]["capacity"] = 2**64 - 1
+
+
+@unittest.mock.patch.dict(configuration._ratelimit, ratelimit_copy)
 class WebsiteTestCase(tornado.testing.AsyncHTTPTestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Closes #242

This fixes the following issues:
1. The way we were consuming tokens from the bucket was flawed, as we were passing the number of tokens to consume as the bucket `key`
2. The number of tokens to consume from each bucket is now dependant on the configuration, instead of the constant value of `1` we used to have.