### PR TITLE
Create/Close resources properly from the BrowserManager

### DIFF
--- a/test/e2e/testscenarios/test_copy_paste.py
+++ b/test/e2e/testscenarios/test_copy_paste.py
@@ -11,23 +11,23 @@ from test.e2e.playwright.browser_manager import BrowserManager
 @pytest.mark.e2e
 def test_copy_paste(playwright: Playwright, request):
     # This test needs to be run in a headed mode for the clipboard to work correctly
-    page = BrowserManager(playwright).create_new_context(headless=False)
-    try:
-        create_paste_page = CreatePastePage(page)
-        create_paste_page.open()
-        first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
-        create_paste_page.click_add_another_file_button()
-        second_pasted_text = create_paste_page.paste_random_text(paste_number=1)
-        create_paste_page.click_submit()
+    with BrowserManager.new_page(playwright, headless=False) as page:
+        try:
+            create_paste_page = CreatePastePage(page)
+            create_paste_page.open()
+            first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
+            create_paste_page.click_add_another_file_button()
+            second_pasted_text = create_paste_page.paste_random_text(paste_number=1)
+            create_paste_page.click_submit()
 
-        view_paste_page = ViewPastePage(page)
-        view_paste_page.should_be_opened()
+            view_paste_page = ViewPastePage(page)
+            view_paste_page.should_be_opened()
 
-        view_paste_page.click_copy_button(related_paste_number=0)
-        verify_clipboard_contents(first_pasted_text)
+            view_paste_page.click_copy_button(related_paste_number=0)
+            verify_clipboard_contents(first_pasted_text)
 
-        view_paste_page.click_copy_button(related_paste_number=1)
-        verify_clipboard_contents(second_pasted_text)
-    except Exception:
-        make_screenshot(request.node, page)
-        raise
+            view_paste_page.click_copy_button(related_paste_number=1)
+            verify_clipboard_contents(second_pasted_text)
+        except Exception:
+            make_screenshot(request.node, page)
+            raise

--- a/test/e2e/testscenarios/test_create_paste.py
+++ b/test/e2e/testscenarios/test_create_paste.py
@@ -1,15 +1,14 @@
 from test.e2e.conftest import create_paste_page
 from test.e2e.pageobjects.create_paste_page import CreatePastePage
 from test.e2e.pageobjects.view_paste_page import ViewPastePage
-from test.e2e.playwright.browser_manager import BrowserManager
 
 import pytest
-from playwright.sync_api import Page, Playwright
+from playwright.sync_api import Page
 
 
 @pytest.mark.e2e
 def test_create_single_paste(
-    page: Page, playwright: Playwright, create_paste_page: CreatePastePage
+    page: Page, create_paste_page: CreatePastePage
 ):
     create_paste_page.should_have_title("Create new paste")
 
@@ -21,12 +20,12 @@ def test_create_single_paste(
     view_paste_page.should_have_pasted_text(pasted_text)
 
     paste_url = view_paste_page.current_url()
-    reopen_created_paste(playwright, paste_url)
+    reopen_created_paste(page, paste_url)
 
 
 @pytest.mark.e2e
 def test_create_multi_paste(
-    page: Page, playwright: Playwright, create_paste_page: CreatePastePage
+    page: Page, create_paste_page: CreatePastePage
 ):
     first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
     create_paste_page.click_add_another_file_button()
@@ -45,11 +44,10 @@ def test_create_multi_paste(
     view_paste_page.should_have_pasted_text(third_pasted_text, paste_number=2)
 
     paste_url = view_paste_page.current_url()
-    reopen_created_paste(playwright, paste_url)
+    reopen_created_paste(page, paste_url)
 
 
-def reopen_created_paste(playwright, paste_url):
-    new_page = BrowserManager(playwright).create_new_context()
-    new_view_paste_page = ViewPastePage(new_page)
+def reopen_created_paste(page: Page, paste_url: str):
+    new_view_paste_page = ViewPastePage(page)
     new_view_paste_page.open(paste_url)
     new_view_paste_page.should_be_opened()


### PR DESCRIPTION
While executing the E2E tests, I noticed that some pages where being opened & not closed, and the same goes for some contexts.

This all came from the `BrowserManager` class, since it made new contexts, but didn't close them unless the entire test session was done.

This change exposes 2 new APIs to make a new context/page, and then close them once exited.