### PR TITLE
feat: press tab inserts language specific num of spaces or default

### DIFF
--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -1,6 +1,10 @@
 let indents = {
+    "default": " ".repeat(4),
     "python": " ".repeat(4),
     "python2": " ".repeat(4),
+    "html": " ".repeat(2),
+    "css": " ".repeat(2),
+    "javascript": " ".repeat(2),
 };
 
 document.addEventListener('keydown', e => {
@@ -120,13 +124,9 @@ function indent_textarea(event) {
 	let selector = event.target.parentNode.parentNode.querySelector("select[name='lexer']"),
 	    lexer = selector.options[selector.selectedIndex].text
 
-	if(!(lexer && lexer.toLowerCase().indexOf("python") == 0)) {
-		return
-	}
-
-    let indent = " ".repeat(4);
-	let keyCode = event.keyCode || event.which;
-
+    let indent = indents[lexer.toLowerCase()] || indents["default"];
+    let keyCode = event.keyCode || event.which;
+    
 	if (keyCode == 9) {
 		event.preventDefault();
 		var start = this.selectionStart;


### PR DESCRIPTION
This is addressing the issue posted here 

https://github.com/supakeen/pinnwand/issues/195

I noticed that there was already this object that wasn't being used

```js
let indents = {
    "default": " ".repeat(4),
    "python": " ".repeat(4),
    "python2": " ".repeat(4),
    "html": " ".repeat(2),
    "css": " ".repeat(2),
    "javascript": " ".repeat(2),
};
```

So I assumed that someone intended to eventually use it and I just decided to plug it in.

The number of indents is determined like this `let indent = indents[lexer.toLowerCase()] || indents["default"];`

The logic that checks for Python is taken out since it's already handled above.

I thought about writing a function `const f = n => " ".repeat(n)` so that the `indents` object could just contain integers, but I didn't really want to make design decisions for you.

The numbers that are put into the languages are obviously opinionated. You could change the defaults to whatever you preferred.