### PR TITLE
test: xfail autodetect

### DIFF
--- a/test/integration/test_utility.py
+++ b/test/integration/test_utility.py
@@ -10,7 +10,8 @@ def test_expiries() -> None:
     assert len(configuration.expiries) == 2
 
 
-def test_guess_language() -> None:
+@pytest.mark.xfail(reason="Pygments incorrectly detects this as `mojo`. Upstream bug to be made.")
+def test_guess_language_broken() -> None:
     # python
     assert (
         utility.guess_language(
@@ -21,6 +22,8 @@ def test_guess_language() -> None:
         )
         == "python"
     )
+
+def test_guess_language() -> None:
     assert (
         utility.guess_language(
             """


### PR DESCRIPTION
Current Pygments versions wrongly detect the sample code in our test as `mojo`. Let's xfail them for now.