### PR TITLE
test: conditional e2e discovery

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ v1.6.1 (unreleased)
 *******************
 * Removed the default indentation from pastes. It now only applies to configured 
   languages again. Opened a public discussion about this behavior.
+* Conditionally discover e2e testcases only when playwright is available in
+  the environment. Closes #284.
 
 v1.6.0 (20241101)
 *******************

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,6 +5,12 @@ import pytest
 from slugify import slugify
 
 
+try:
+    import playwright
+except ImportError:
+    collect_ignore = ["e2e/"]
+
+
 def pytest_addoption(parser):
     parser.addoption(
         "--e2e",


### PR DESCRIPTION
When pytest discovers test files to run it executes the files (or something like it). This means that imports must be available at that point in time.

Let's add an import check to `conftest.py` to ignore discovery in the e2e subdirectory when playwright is not available.

This closes #284.