### PR TITLE
javascript: remove default indentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 ``pinnwand`` is Python pastebin software that tried to keep it simple but got
 a little more complex.
 
+v1.6.1 (unreleased)
+*******************
+* Removed the default indentation from pastes. It now only applies to configured 
+  languages again. Opened a public discussion about this behavior.
+
 v1.6.0 (20241101)
 *******************
 * Added a browser test suite by nekhvoya_.

--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -1,5 +1,4 @@
 let indents = {
-    "default": " ".repeat(4),
     "python": " ".repeat(4),
     "python2": " ".repeat(4),
     "html": " ".repeat(2),
@@ -124,7 +123,12 @@ function indent_textarea(event) {
 	let selector = event.target.parentNode.parentNode.querySelector("select[name='lexer']"),
 	    lexer = selector.options[selector.selectedIndex].text
 
-    let indent = indents[lexer.toLowerCase()] || indents["default"];
+    let indent = indents[lexer.toLowerCase()];
+
+    if(!indent) {
+        return;
+    }
+
     let keyCode = event.keyCode || event.which;
     
 	if (keyCode == 9) {


### PR DESCRIPTION
We had enabled indentation and tab-conversion by default. Let's discuss that further as it seems to be controversial-ish.

See: https://github.com/supakeen/pinnwand/issues/292