### PR TITLE
OpenRC: example init script

### DIFF
--- a/etc/openrc/pinnwand.confd
+++ b/etc/openrc/pinnwand.confd
@@ -1,0 +1,32 @@
+###
+# pinnwand init.d configuration
+###
+
+# Path to the Pinnwand configuration file.
+config_file="/home/pinnwand/pinnwand_config.toml"
+
+# User and group under which the Pinnwand service will run.
+pinnwand_user="pinnwand:pinnwand"
+
+# Port on which the Pinnwand service will listen for HTTP requests..
+port=9000
+
+# Path to the Pinnwand executable.
+command="/home/pinnwand/venv/bin/pinnwand"
+
+# Directory where logs will be stored.
+#log_dir="/var/log"
+
+# Path to the standard output log file for the Pinnwand service..
+#output_log="${log_dir}/pinnwand.log"
+
+# Path to the error log file for the Pinnwand service.
+#error_log="${log_dir}/pinnwand.err"
+
+# Override arguments passed to the Pinnwand command at startup.
+# -v: Enable verbose logging.
+# --configuration-path: Specify the path to the configuration file.
+# http: Start the HTTP server.
+# --port: Specify the port on which the service will listen.
+
+#command_args="-v --configuration-path \"${config_file}\" http --port ${port}"

--- a/etc/openrc/pinnwand.initd
+++ b/etc/openrc/pinnwand.initd
@@ -1,0 +1,24 @@
+#!/sbin/openrc-run
+
+description="Pinnwand pastebin service"
+
+config_file="${config_file:-/home/pinnwand/pinnwand_config.toml}"
+port="${port:-9000}"
+log_dir="${log_dir:-/var/log}"
+output_log="${output_log:-$log_dir/$RC_SVCNAME.log}"
+error_log="${error_log:-$log_dir/$RC_SVCNAME.err}"
+pidfile="${pidfile:-/run/$RC_SVCNAME.pid}"
+command="${command:-/home/pinnwand/venv/bin/pinnwand}"
+command_user="${pinnwand_user:-pinnwand:pinnwand}"
+command_args="${command_args:- --configuration-path \"$config_file\" http --port $port}"
+command_background=true
+
+start_pre() {
+	if [ ! -f "$config_file" ]; then
+		eerror "Configuration file not found: $config_file"
+		return 1
+	fi
+
+	checkpath --file --owner "$command_user" --mode 0664 "$output_log"
+	checkpath --file --owner "$command_user" --mode 0664 "$error_log"
+}


### PR DESCRIPTION
Adding an example OpenRC init script for use with OpenRC distros like Gentoo and Alpine Linux.

* `pinnwand.initd` should be copied to `/etc/init.d/pinnwand` and be made executable.
* `pinnwand.confd` should be copied to /etc/conf.d/pinnwand 
* adjust the conf.d file to suit your needs.

### background
I use Gentoo, and unfortunately, pinnwand is not packaged for Gentoo yet. I created the OpenRC scripts for my own use and thought that they may be useful for others.
