### PR TITLE
feat(pre-commit): add pdm-export hook to generate requirements.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,8 @@ repos:
       entry: python -m bandit
       types: [python]
       exclude: ^doc/conf.py|^test
+    - id: pdm-export
+      name: pdm-export
+      language: system
+      pass_filenames: false
+      entry: pdm export -f requirements -o requirements.txt


### PR DESCRIPTION
Generation of the requirement.txt with a pre-commit hook makes maintaining the requirements.txt file more easier and consistent.