### PR TITLE
Fix spam score regex (add non-captured groups)

### DIFF
--- a/src/pinnwand/defensive.py
+++ b/src/pinnwand/defensive.py
@@ -68,9 +68,8 @@ def spamscore(text: str) -> int:
     This will then give a value 0-100, which can be used with a configuration
     option to deny pastes over a certain percentage."""
 
-    # TODO Is this a good URL regex?
     match = re.compile(
-        r"((http|ws|grpc|ftp)s?.//[a-z-]+\.[a-z]+/?[^\"\'\ \n\r\t\v]+)"
+        r"(?:http|ws|grpc|ftp)(?:s?.//[a-z-]+\.[a-z]+/?[^\"\'\ \n\r\t\v]+)"
     )
 
     text_size = len(text)


### PR DESCRIPTION
Added non-capture groups to regex, so that found url's are not summarized multiple times.

I built the project with the updated master branch and now it doesn't block my paste, but I also found that the spam block doesn't work when needed. This is because first of all the result was folded into nested tuples and instead of the sum of characters in the lines it counted the number of nested lines, and the spam block didn't work at all. I checked the edit locally - now everything works fine. Thanks!