### PR TITLE
Replace pdm-pep517 with pdm-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,8 @@ dev = [
     "toml>=0.10.2",
 ]
 [build-system]
-requires = ["pdm-pep517>=1.0"]
-build-backend = "pdm.pep517.api"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [project.scripts]
 pinnwand = 'pinnwand.__main__:main'


### PR DESCRIPTION
Per https://pypi.org/project/pdm-pep517/

> This project has been renamed and re-published as pdm-backend