### PR TITLE
Fix hitting enter from filename removes file

### DIFF
--- a/src/pinnwand/static/pinnwand.js
+++ b/src/pinnwand/static/pinnwand.js
@@ -43,6 +43,7 @@ function getFirstEmptyFilePartSection() {
 
 function addRemoveButtons() {
     const tag = "button";
+    const buttonType = "button";
     const className = "remove";
     const label = "Remove this file";
     const selector = `${tag}.${className}`;
@@ -59,6 +60,7 @@ function addRemoveButtons() {
             return;
         }
         const removeButton = document.createElement(tag);
+        removeButton.type = buttonType;
         removeButton.innerText = label;
         removeButton.className = className;
         el.appendChild(removeButton);

--- a/test/e2e/pageobjects/create_paste_page.py
+++ b/test/e2e/pageobjects/create_paste_page.py
@@ -115,6 +115,10 @@ class CreatePastePage(BasePage):
         log.info(f"Typing file name {name}")
         self.filename_input.nth(paste_number).type(name)
 
+    def hit_enter_from_filename(self, paste_number=0):
+        log.info(f"Hitting enter from file name field on paste {paste_number}")
+        self.filename_input.nth(paste_number).press("Enter")
+
     def set_filetype(self, value, paste_number=0):
         log.info(f"Typing file type {value}")
         self.filetype_select.nth(paste_number).select_option(value)

--- a/test/e2e/testscenarios/test_create_paste.py
+++ b/test/e2e/testscenarios/test_create_paste.py
@@ -47,6 +47,27 @@ def test_create_multi_paste(
     reopen_created_paste(page, paste_url)
 
 
+@pytest.mark.e2e
+def test_create_multi_paste_implicit_submit(
+    page: Page, create_paste_page: CreatePastePage
+):
+    first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
+    create_paste_page.set_random_filename(paste_number=0)
+    create_paste_page.click_add_another_file_button()
+
+    second_pasted_text = create_paste_page.paste_random_text(paste_number=1)
+    create_paste_page.set_random_filename(paste_number=1)
+    create_paste_page.hit_enter_from_filename(paste_number=1)
+
+    view_paste_page = ViewPastePage(page)
+    view_paste_page.should_be_opened()
+    view_paste_page.should_have_pasted_text(first_pasted_text, paste_number=0)
+    view_paste_page.should_have_pasted_text(second_pasted_text, paste_number=1)
+
+    paste_url = view_paste_page.current_url()
+    reopen_created_paste(page, paste_url)
+
+
 def reopen_created_paste(page: Page, paste_url: str):
     new_view_paste_page = ViewPastePage(page)
     new_view_paste_page.open(paste_url)


### PR DESCRIPTION
Since the Remove button's type was not set, it defaulted to "submit", so the browser would use the topmost Remove button for implicit submissions instead of the actual submit button (the Paste button).

Fixes #345