### PR TITLE
Fix E2E test tautologies and resulting bad tests

### DIFF
--- a/test/e2e/pageobjects/create_paste_page.py
+++ b/test/e2e/pageobjects/create_paste_page.py
@@ -152,15 +152,13 @@ class CreatePastePage(BasePage):
 
     def should_have_selected_filetype(self, filetype, paste_number=0):
         assert (
-            self.selected_option.nth(paste_number).text_content() == filetype,
-            f"Incorrect option was selected in Filetype Select on {self.page_name}",
-        )
+            self.selected_option.nth(paste_number).text_content() == filetype
+        ), f"Incorrect option was selected in Filetype Select on {self.page_name}"
 
     def should_have_paste_inputs(self, number_of_paste_inputs):
         assert (
-            len(self.paste_input.all()) == number_of_paste_inputs,
-            f"{self.page_name} had incorrect number of Paste Inputs",
-        )
+            len(self.paste_input.all()) == number_of_paste_inputs
+        ), f"{self.page_name} had incorrect number of Paste Inputs"
 
 
 class RemovalConfirmationModal:

--- a/test/e2e/pageobjects/view_paste_page.py
+++ b/test/e2e/pageobjects/view_paste_page.py
@@ -112,8 +112,8 @@ class ViewPastePage(BasePage):
         ), f"Length of paste slug was incorrect on {self.page_name}:\nActual: {actual_length}\nExpected: {length}"
 
     def should_have_paste_formatting(self, value, paste_number=0):
-        assert (
-            f"lang-{value}"
-            in self.pasted_file.nth(paste_number).get_attribute("class"),
-            f"Formatting of pasted file was incorrect on {self.page_name}",
-        )
+        assert f"lang-{value}" in self.pasted_file.nth(
+            paste_number
+        ).get_attribute(
+            "class"
+        ), f"Formatting of pasted file was incorrect on {self.page_name}"

--- a/test/e2e/testscenarios/test_filetype.py
+++ b/test/e2e/testscenarios/test_filetype.py
@@ -21,11 +21,11 @@ def test_default_filetype(page: Page, create_paste_page: CreatePastePage):
 @pytest.mark.e2e
 def test_set_filetype(page: Page, create_paste_page: CreatePastePage):
     create_paste_page.paste_random_text(paste_number=0)
-    create_paste_page.set_filetype(Filetype.GO.value["value"])
+    create_paste_page.set_filetype(Filetype.GO.value["value"], paste_number=0)
     create_paste_page.click_add_another_file_button()
 
     create_paste_page.paste_random_text(paste_number=1)
-    create_paste_page.set_filetype(Filetype.JAVA.value["value"])
+    create_paste_page.set_filetype(Filetype.JAVA.value["value"], paste_number=1)
     create_paste_page.click_submit()
 
     view_paste_page = ViewPastePage(page)
@@ -51,7 +51,7 @@ def test_reset_filetype(page: Page, create_paste_page: CreatePastePage):
     view_paste_page.click_repaste_button()
     create_paste_page.should_be_opened()
     create_paste_page.should_have_selected_filetype(
-        Filetype.JAVASCRIPT.value["value"]
+        Filetype.JAVASCRIPT.value["label"]
     )
     create_paste_page.set_filetype(Filetype.JSON.value["value"])
     create_paste_page.click_submit()

--- a/test/e2e/utils/file_utils.py
+++ b/test/e2e/utils/file_utils.py
@@ -28,10 +28,9 @@ def extract_file_name(file_path):
 
 def verify_downloaded_file_name(download, name_regex):
     def assert_file_name(file):
-        assert (
-            re.compile(name_regex).match(extract_filename(file.name)),
-            f"Name of file {file.name} was not {name_regex}",
-        )
+        assert re.compile(name_regex).match(
+            extract_filename(file.name)
+        ), f"Name of file {file.name} was not {name_regex}"
 
     verify_downloaded_file(download, assert_file_name)
 
@@ -39,10 +38,7 @@ def verify_downloaded_file_name(download, name_regex):
 def verify_downloaded_file_contents(download, text):
     def assert_file_contents(file):
         file_content = file.read()
-        assert (
-            file_content == text,
-            f"Contents of file was not equal to {text}",
-        )
+        assert file_content == text, f"Contents of file was not equal to {text}"
 
     verify_downloaded_file(download, assert_file_contents)
 


### PR DESCRIPTION
This fixes the always-true assertions that show up as `SyntaxWarning` in the E2E tests, and fixes the tests that wound up failing due to the corrected assertions.

Fixes #346