### PR TITLE
Blacken tests too

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,7 +19,7 @@ jobs:
         pip install black codespell types-docutils mypy
 
     - name: Check with black
-      run: black --check src/pinnwand
+      run: black --check src/pinnwand test
 
     # - name: Check with mypy
     #   run: mypy src/pinnwand

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     - id: black
       name: black
       language: system
-      entry: python -m black
+      entry: python -m black --check src/pinnwand test
       types: [python]
     - id: pytest
       name: pytest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 from slugify import slugify
 
-
 try:
     import playwright
 except ImportError:

--- a/test/e2e/playwright/browser_manager.py
+++ b/test/e2e/playwright/browser_manager.py
@@ -11,7 +11,9 @@ class BrowserManager:
 
     @classmethod
     @contextlib.contextmanager
-    def new_context(cls, playwright: Playwright, headless: Optional[bool] = None) -> BrowserContext:
+    def new_context(
+        cls, playwright: Playwright, headless: Optional[bool] = None
+    ) -> BrowserContext:
         log.info("creating new browser context")
         headless = headless if headless is not None else is_headless()
         browser = playwright.chromium.launch(headless=headless)
@@ -25,9 +27,13 @@ class BrowserManager:
 
     @classmethod
     @contextlib.contextmanager
-    def new_page(cls, playwright: Playwright, headless: Optional[bool] = None) -> Page:
+    def new_page(
+        cls, playwright: Playwright, headless: Optional[bool] = None
+    ) -> Page:
         headless = headless if headless is not None else is_headless()
-        with cls.new_context(playwright=playwright, headless=headless) as context:
+        with cls.new_context(
+            playwright=playwright, headless=headless
+        ) as context:
             page = context.new_page()
             try:
                 yield page
@@ -35,4 +41,3 @@ class BrowserManager:
                 log.exception(e)
             finally:
                 page.close()
-

--- a/test/e2e/testscenarios/test_copy_paste.py
+++ b/test/e2e/testscenarios/test_copy_paste.py
@@ -15,9 +15,13 @@ def test_copy_paste(playwright: Playwright, request):
         try:
             create_paste_page = CreatePastePage(page)
             create_paste_page.open()
-            first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
+            first_pasted_text = create_paste_page.paste_random_text(
+                paste_number=0
+            )
             create_paste_page.click_add_another_file_button()
-            second_pasted_text = create_paste_page.paste_random_text(paste_number=1)
+            second_pasted_text = create_paste_page.paste_random_text(
+                paste_number=1
+            )
             create_paste_page.click_submit()
 
             view_paste_page = ViewPastePage(page)

--- a/test/e2e/testscenarios/test_create_paste.py
+++ b/test/e2e/testscenarios/test_create_paste.py
@@ -7,9 +7,7 @@ from playwright.sync_api import Page
 
 
 @pytest.mark.e2e
-def test_create_single_paste(
-    page: Page, create_paste_page: CreatePastePage
-):
+def test_create_single_paste(page: Page, create_paste_page: CreatePastePage):
     create_paste_page.should_have_title("Create new paste")
 
     pasted_text = create_paste_page.paste_random_text()
@@ -24,9 +22,7 @@ def test_create_single_paste(
 
 
 @pytest.mark.e2e
-def test_create_multi_paste(
-    page: Page, create_paste_page: CreatePastePage
-):
+def test_create_multi_paste(page: Page, create_paste_page: CreatePastePage):
     first_pasted_text = create_paste_page.paste_random_text(paste_number=0)
     create_paste_page.click_add_another_file_button()
 

--- a/test/integration/test_defensive.py
+++ b/test/integration/test_defensive.py
@@ -14,7 +14,9 @@ def test_spamscore_only_links() -> None:
 
 
 def test_spamscore_mixed_content() -> None:
-    text = "Check out https://example.com for more information about our product."
+    text = (
+        "Check out https://example.com for more information about our product."
+    )
     score = defensive.spamscore(text)
     assert 0 < score < 100
     # ~23 chars out of ~70 total: ~32%

--- a/test/integration/test_http_ratelimit.py
+++ b/test/integration/test_http_ratelimit.py
@@ -14,7 +14,9 @@ class RateLimitTestCase(tornado.testing.AsyncHTTPTestCase):
         return app.make_application()
 
     def test_ratelimit_verification_on_endpoints(self):
-        with unittest.mock.patch("pinnwand.defensive.should_be_ratelimited") as patch:
+        with unittest.mock.patch(
+            "pinnwand.defensive.should_be_ratelimited"
+        ) as patch:
             patch.return_value = False
 
             self.fetch(
@@ -32,8 +34,13 @@ class RateLimitTestCase(tornado.testing.AsyncHTTPTestCase):
         ratelimlit_copy["read"]["consume"] = 2
         ratelimlit_copy["read"]["refill"] = 1
 
-        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
-            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+        with unittest.mock.patch.dict(
+            "pinnwand.defensive.ConfigurationProvider._config._ratelimit",
+            ratelimlit_copy,
+        ):
+            with unittest.mock.patch.dict(
+                "pinnwand.defensive.ratelimit_area", clear=True
+            ):
                 response = self.fetch(
                     "/",
                     method="GET",
@@ -59,8 +66,13 @@ class RateLimitTestCase(tornado.testing.AsyncHTTPTestCase):
         ip1 = "192.168.15.32"
         ip2 = "10.45.134.23"
 
-        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
-            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+        with unittest.mock.patch.dict(
+            "pinnwand.defensive.ConfigurationProvider._config._ratelimit",
+            ratelimlit_copy,
+        ):
+            with unittest.mock.patch.dict(
+                "pinnwand.defensive.ratelimit_area", clear=True
+            ):
                 assert defensive.should_be_ratelimited(ip1, area) is False
                 assert defensive.should_be_ratelimited(ip1, area) is True
                 assert defensive.should_be_ratelimited(ip2, area) is False
@@ -81,10 +93,16 @@ class RateLimitTestCase(tornado.testing.AsyncHTTPTestCase):
         ratelimlit_copy[area]["refill"] = 1
 
         ip = "192.168.15.32"
-        with unittest.mock.patch.dict("pinnwand.defensive.ConfigurationProvider._config._ratelimit", ratelimlit_copy):
-            with unittest.mock.patch.dict("pinnwand.defensive.ratelimit_area", clear=True):
+        with unittest.mock.patch.dict(
+            "pinnwand.defensive.ConfigurationProvider._config._ratelimit",
+            ratelimlit_copy,
+        ):
+            with unittest.mock.patch.dict(
+                "pinnwand.defensive.ratelimit_area", clear=True
+            ):
                 defensive.should_be_ratelimited(ip, area)
                 limiter = defensive.ratelimit_area[area]
-                tokens_remaining = limiter._storage.get_token_count(ip.encode("utf-8"))
+                tokens_remaining = limiter._storage.get_token_count(
+                    ip.encode("utf-8")
+                )
                 assert tokens_remaining == capacity - consumption
-

--- a/test/integration/test_utility.py
+++ b/test/integration/test_utility.py
@@ -10,18 +10,16 @@ def test_expiries() -> None:
     assert len(configuration.expiries) == 2
 
 
-@pytest.mark.xfail(reason="Pygments incorrectly detects this as `mojo`. Upstream bug to be made.")
+@pytest.mark.xfail(
+    reason="Pygments incorrectly detects this as `mojo`. Upstream bug to be made."
+)
 def test_guess_language_broken() -> None:
     # python
-    assert (
-        utility.guess_language(
-            """
+    assert utility.guess_language("""
       import math
       math.ceil(0.5)
-    """
-        )
-        == "python"
-    )
+    """) == "python"
+
 
 def test_guess_language() -> None:
     assert (
@@ -47,15 +45,11 @@ def test_guess_language() -> None:
     )
 
     # php
-    assert utility.guess_language(
-        """
+    assert utility.guess_language("""
       <?php
       $var = 0.5;
       abs($var);
-    """
-    ).endswith(
-        "php"
-    )  # for some reason this is guessed as js+php
+    """).endswith("php")  # for some reason this is guessed as js+php
 
     # yaml
     assert (


### PR DESCRIPTION
Fixes #349.

1. Blacken `test/`.
2. Update GitHub Actions lint workflow to `black --check` against `test/` as well.
3. Update pre-commit `black` script to target `test/` as well.
4. Update pre-commit `black` script to use `--check` so it won't try to edit things in a git hook.

The last thing is the only part I'm not sure about. I believe pre-commit things shouldn't ever *edit*, just check and balk if something is wrong, but it's not my repo. Your call, @supakeen :)

