### PR TITLE
Set 'long' checkbox to checked by default

### DIFF
--- a/src/pinnwand/template/create.html
+++ b/src/pinnwand/template/create.html
@@ -41,7 +41,7 @@
                 <option value="{{ expiry }}">Expiry ({{ expiry }})</option>
                 {% end %}
             </select>
-            <input type="checkbox" name="long"> Use a longer URI
+            <input type="checkbox" name="long" checked> Use a longer URI
         </section>
         <section class="file-drop" id="file-drop">
             Drop files&nbsp;<a id="file-upload" class="file-upload" onclick="document.getElementById('file-input').click();">or click here</a>&nbsp;to upload files


### PR DESCRIPTION
Short URIs on a fresh instance can be as short as 2 characters, which makes them easy to guess and enumerate. Default the "Use a longer URI" checkbox to checked so longer slugs are used by default, with shorter ones available as opt-in.